### PR TITLE
feature/display-unit-skill-level

### DIFF
--- a/src/app/ffbe/characters/characters.component.html
+++ b/src/app/ffbe/characters/characters.component.html
@@ -11,5 +11,5 @@
 </mat-card>
 <app-character-display *ngIf="isCharacterDisplayed()" [personnage]="personnage"></app-character-display>
 <app-character-skills-display *ngIf="isCharacterSkillsDisplayed()"
-                              [competences]="personnage.unites[personnage.unites.length -1].competences">
+                              [competences]="competences">
 </app-character-skills-display>

--- a/src/app/ffbe/characters/characters.component.ts
+++ b/src/app/ffbe/characters/characters.component.ts
@@ -7,6 +7,7 @@ import {SkillsService} from '../services/skills.service';
 import {Character} from '../model/character.model';
 import {CharacterMapper} from '../mappers/character-mapper';
 import {isNullOrUndefined} from 'util';
+import {Competence} from '../model/competence.model';
 
 @Component({
   selector: 'app-characters',
@@ -17,6 +18,7 @@ export class CharactersComponent implements OnInit {
 
   name: FormControl;
   personnage: Personnage;
+  competences: Array<Competence>;
 
   constructor(private charactersService: CharactersService,
               private limitBurstsService: LimitBurstsService,
@@ -29,9 +31,12 @@ export class CharactersComponent implements OnInit {
 
   public searchCharacterInDataMining() {
     this.personnage = null;
+    this.competences = [];
     const character: Character = this.charactersService.searchForCharacterByName(this.name.value);
     if (character) {
       this.personnage = CharacterMapper.toPersonnage(character);
+      this.personnage.unites[this.personnage.unites.length - 1].competences
+        .forEach(uniteCompetence => this.competences.push(uniteCompetence.competence));
     }
   }
 
@@ -40,10 +45,7 @@ export class CharactersComponent implements OnInit {
   }
 
   public isCharacterSkillsDisplayed(): boolean {
-    return this.personnage != null
-      && Array.isArray(this.personnage.unites)
-      && this.personnage.unites.length > 0
-      && Array.isArray(this.personnage.unites[this.personnage.unites.length - 1].competences);
+    return Array.isArray(this.competences) && this.competences.length > 0;
   }
 
   public isDataMiningLoading(): boolean {

--- a/src/app/ffbe/mappers/character-mapper.ts
+++ b/src/app/ffbe/mappers/character-mapper.ts
@@ -7,6 +7,7 @@ import {FfbeUtils} from '../utils/ffbe-utils';
 import {Competence} from '../model/competence.model';
 import {Equipment} from '../model/equipment.model';
 import {SkillMapper} from './skill-mapper';
+import {UniteCompetence} from '../model/unite-competence.model';
 
 export class CharacterMapper {
 
@@ -28,7 +29,12 @@ export class CharacterMapper {
       const competence: Competence = SkillMapper.toCompetence(characterSkill.skill);
       perso.unites
         .filter(unite => unite.stars >= characterSkill.rarity)
-        .forEach(unite => unite.competences.push(competence));
+        .forEach(unite => unite.competences.push(
+          new UniteCompetence(unite,
+            competence,
+            unite.stars > characterSkill.rarity ? 1 : characterSkill.level
+          )
+        ));
     });
     return perso;
   }

--- a/src/app/ffbe/model/unite-competence.model.ts
+++ b/src/app/ffbe/model/unite-competence.model.ts
@@ -1,0 +1,9 @@
+import {Competence} from './competence.model';
+import {Unite} from './unite.model';
+
+export class UniteCompetence {
+  constructor(public unite: Unite,
+              public competence: Competence,
+              public niveau: number) {
+  }
+}

--- a/src/app/ffbe/model/unite.model.ts
+++ b/src/app/ffbe/model/unite.model.ts
@@ -1,6 +1,6 @@
 import {Personnage} from './personnage.model';
-import {Competence} from './competence.model';
 import {UniteCarac} from './unite-carac.model';
+import {UniteCompetence} from './unite-competence.model';
 
 export class Unite {
   public limite: string;
@@ -10,7 +10,7 @@ export class Unite {
   public lim_nb_niv: number;
   public lim_hits: number;
   public lim_frames: string;
-  public competences: Array<Competence> = [];
+  public competences: Array<UniteCompetence> = [];
   public carac: UniteCarac;
 
   constructor(public perso: Personnage,

--- a/src/app/ffbe/unit-display/unit-display.component.html
+++ b/src/app/ffbe/unit-display/unit-display.component.html
@@ -67,14 +67,21 @@
 
   <mat-table [dataSource]="unite.competences">
 
+    <ng-container matColumnDef="level">
+      <mat-header-cell *matHeaderCellDef>Niveau</mat-header-cell>
+      <mat-cell *matCellDef="let uniteCompetence">{{uniteCompetence.niveau}}</mat-cell>
+    </ng-container>
+
     <ng-container matColumnDef="id_nom">
       <mat-header-cell *matHeaderCellDef>Id et nom</mat-header-cell>
-      <mat-cell *matCellDef="let competence">{{competence.gumi_id}} {{competence.nom}}</mat-cell>
+      <mat-cell *matCellDef="let uniteCompetence">{{uniteCompetence.competence.gumi_id}}
+        {{uniteCompetence.competence.nom}}
+      </mat-cell>
     </ng-container>
 
     <ng-container matColumnDef="description">
       <mat-header-cell *matHeaderCellDef>Description</mat-header-cell>
-      <mat-cell *matCellDef="let competence">{{competence.description}}</mat-cell>
+      <mat-cell *matCellDef="let uniteCompetence">{{uniteCompetence.competence.description}}</mat-cell>
     </ng-container>
 
     <mat-header-row *matHeaderRowDef="skillsColumnsToDisplay"></mat-header-row>

--- a/src/app/ffbe/unit-display/unit-display.component.ts
+++ b/src/app/ffbe/unit-display/unit-display.component.ts
@@ -9,7 +9,7 @@ import {Unite} from '../model/unite.model';
 export class UnitDisplayComponent implements OnInit {
 
   @Input() unite: Unite;
-  skillsColumnsToDisplay = ['id_nom', 'description'];
+  skillsColumnsToDisplay = ['level', 'id_nom', 'description'];
 
   constructor() {
   }


### PR DESCRIPTION
Adding an intermediate model object between Unite and Competence, named UniteCompetence, to hold the acquiring level.
Now displaying the acquiring level for each unit skills.
Extracting the list of Competence from the list of the highest rank character list of UniteCompetence for a proper use of CharacterSkillsDisplay component.