### PR TITLE
Fixed the method transformIcon in the skill mapper

### DIFF
--- a/src/app/ffbe/mappers/skill-mapper.ts
+++ b/src/app/ffbe/mappers/skill-mapper.ts
@@ -53,8 +53,8 @@ export class SkillMapper {
   private static transformIcon(icon: string): number {
     if (icon) {
       const underscoreSplitted = icon.split('_');
-      if (Array.isArray(underscoreSplitted) && underscoreSplitted.length === 2) {
-        const pointSplitted = underscoreSplitted[1].split('.');
+      if (Array.isArray(underscoreSplitted) && underscoreSplitted.length >= 2) {
+        const pointSplitted = underscoreSplitted[underscoreSplitted.length-1].split('.');
         if (Array.isArray(pointSplitted) && pointSplitted.length === 2) {
           return +(pointSplitted[0]);
         }


### PR DESCRIPTION
The method was designed for icons named "ability_xyz.png".
However global abilities are named "global_ability_xyz.png"