### PR TITLE
Changed wording for the AbilityDamagesMagicSprScalingParser ...

### DIFF
--- a/src/app/ffbe/mappers/effects/abilities/ability-damages-magic-spr-scaling.parser.spec.ts
+++ b/src/app/ffbe/mappers/effects/abilities/ability-damages-magic-spr-scaling.parser.spec.ts
@@ -12,7 +12,7 @@ describe('AbilityDamagesMagicSprScalingParser', () => {
     // WHEN
     const s = AbilityEffectParserFactory.getParser(effect[0], effect[1], effect[2]).parse(effect, fakeSkill);
     // THEN
-    expect(s).toEqual('Dégâts magiques neutres calculé sur la PSY de puissance 300% à un adversaire');
+    expect(s).toEqual('Dégâts magiques neutres calculés sur la PSY de puissance 300% à un adversaire');
   });
 
   it('should parse physical attack with magic elemental damages scaling on SPR', () => {
@@ -24,7 +24,7 @@ describe('AbilityDamagesMagicSprScalingParser', () => {
     // WHEN
     const s = AbilityEffectParserFactory.getParser(effect[0], effect[1], effect[2]).parse(effect, fakeSkill);
     // THEN
-    expect(s).toEqual('Attaque physique à dégâts magiques de Glace, Foudre, Vent calculé sur la PSY de puissance 500% aux adversaires');
+    expect(s).toEqual('Attaque physique à dégâts magiques de Glace, Foudre, Vent calculés sur la PSY de puissance 500% aux adversaires');
   });
 
 });

--- a/src/app/ffbe/mappers/effects/abilities/ability-damages-magic-spr-scaling.parser.ts
+++ b/src/app/ffbe/mappers/effects/abilities/ability-damages-magic-spr-scaling.parser.ts
@@ -13,6 +13,6 @@ export class AbilityDamagesMagicSprScalingParser extends EffectParser {
     const puissance = effect[3][2];
     const target = this.getTarget(effect[0], effect[1]);
     return attackType + (elements ? 'de ' + elements + ' ' : 'neutres ')
-      + 'calculé sur la PSY de puissance ' + Math.round(puissance) + '% ' + target;
+      + 'calculés sur la PSY de puissance ' + Math.round(puissance) + '% ' + target;
   }
 }

--- a/src/app/ffbe/mappers/effects/abilities/ability-damages-physical-def-scaling.parser.spec.ts
+++ b/src/app/ffbe/mappers/effects/abilities/ability-damages-physical-def-scaling.parser.spec.ts
@@ -12,7 +12,7 @@ describe('AbilityDamagesPhysicalDefScalingParser', () => {
     // WHEN
     const s = AbilityEffectParserFactory.getParser(effect[0], effect[1], effect[2]).parse(effect, fakeSkill);
     // THEN
-    expect(s).toEqual('Dégâts physiques neutres calculé sur la DÉF de puissance 300% à un adversaire');
+    expect(s).toEqual('Dégâts physiques neutres calculés sur la DÉF de puissance 300% à un adversaire');
   });
 
   it('should parse magic attack with physical elemental damages scaling on DEF', () => {
@@ -24,7 +24,7 @@ describe('AbilityDamagesPhysicalDefScalingParser', () => {
     // WHEN
     const s = AbilityEffectParserFactory.getParser(effect[0], effect[1], effect[2]).parse(effect, fakeSkill);
     // THEN
-    expect(s).toEqual('Attaque magique à dégâts physiques de Glace, Foudre, Vent calculé sur la DÉF de puissance 500% aux adversaires');
+    expect(s).toEqual('Attaque magique à dégâts physiques de Glace, Foudre, Vent calculés sur la DÉF de puissance 500% aux adversaires');
   });
 
 });

--- a/src/app/ffbe/mappers/effects/abilities/ability-damages-physical-def-scaling.parser.ts
+++ b/src/app/ffbe/mappers/effects/abilities/ability-damages-physical-def-scaling.parser.ts
@@ -12,6 +12,6 @@ export class AbilityDamagesPhysicalDefScalingParser extends EffectParser {
     skill.physique = true;
     const puissance = effect[3][2];
     const target = this.getTarget(effect[0], effect[1]);
-    return attackType + (elements ? 'de ' + elements + ' ' : 'neutres ') + 'calculé sur la DÉF de puissance ' + Math.round(puissance) + '% ' + target;
+    return attackType + (elements ? 'de ' + elements + ' ' : 'neutres ') + 'calculés sur la DÉF de puissance ' + Math.round(puissance) + '% ' + target;
   }
 }


### PR DESCRIPTION
... and the AbilityDamagesPhysicalDefScalingParser

The computation is made for the damages, adapted wording to reflect this.