### PR TITLE
Physical/Hybrid CD's without double DW activation

### DIFF
--- a/src/app/ffbe/mappers/effects/abilities/ability-cooldown-parser.ts
+++ b/src/app/ffbe/mappers/effects/abilities/ability-cooldown-parser.ts
@@ -35,8 +35,11 @@ export class AbilityCooldownParser extends EffectParser {
       return baseText + 'UNKNOWN skill';
     }
 
+    const singleActivationNotice = (suffix === 0 && (skill.attack_type === 'Physical' || skill.attack_type === 'Hybrid')) ?
+      '<br />Ne s\'active qu\'<strong>une fois</strong> si l\'unité porte deux armes' : '';
+
     const transitiveEffectParsed = SkillMapper.toCompetence(activatedSkill).effet_fr;
     this.fillSkillWithTransitiveActivatedSkillInformation(skill, activatedSkill);
-    return baseText + transitiveEffectParsed;
+    return baseText + transitiveEffectParsed + singleActivationNotice;
   }
 }

--- a/src/app/ffbe/mappers/effects/abilities/ability-cooldown-parser.ts
+++ b/src/app/ffbe/mappers/effects/abilities/ability-cooldown-parser.ts
@@ -36,7 +36,7 @@ export class AbilityCooldownParser extends EffectParser {
     }
 
     const singleActivationNotice = (suffix === 0 && (skill.attack_type === 'Physical' || skill.attack_type === 'Hybrid')) ?
-      '<br />Ne s\'active qu\'<strong>une fois</strong> si l\'unité porte deux armes' : '';
+      `${HTML_LINE_RETURN}Ne s\'active qu\'<strong>une fois</strong> si l\'unité porte deux armes` : '';
 
     const transitiveEffectParsed = SkillMapper.toCompetence(activatedSkill).effet_fr;
     this.fillSkillWithTransitiveActivatedSkillInformation(skill, activatedSkill);


### PR DESCRIPTION
Adapted the AbilityCooldownParser to handle cooldowns that trigger only once when dual-wielding.
Fixes #101 