### PR TITLE
Fixes #99: Push counter-attacks with damages as skills

### DIFF
--- a/src/app/ffbe/mappers/effects/passive-effect-parser.factory.spec.ts
+++ b/src/app/ffbe/mappers/effects/passive-effect-parser.factory.spec.ts
@@ -256,6 +256,28 @@ describe('PassiveEffectParser', () => {
     expect(s).toEqual('15% de chance de contrer les dégâts magiques par: +20% PV');
   });
 
+  it('should parse counter attack with skill with chain damages', () => {
+    // GIVEN
+    const skills = JSON.parse(ABILITY_SKILLS_TEST_DATA);
+    const skill: Skill = skills['509624'];
+    const names = JSON.parse(ABILITY_SKILLS_NAMES_TEST_DATA);
+    skill.names = names['509624'];
+    const descriptions = JSON.parse(ABILITY_SKILLS_SHORTDESCRIPTIONS_TEST_DATA);
+    skill.descriptions = descriptions['509624'];
+    skill.active = true;
+    skill.gumi_id = 509624;
+
+    const effect = JSON.parse('[0, 3, 49, [15, 3, 509624]]');
+    const skillsServiceMock = new SkillsServiceMock() as SkillsService;
+    SkillsService['INSTANCE'] = skillsServiceMock;
+    spyOn(skillsServiceMock, 'searchForSkillByGumiId').and.returnValue(Skill.produce(skill));
+    // WHEN
+    const s = PassiveEffectParserFactory.getParser(effect[0], effect[1], effect[2]).parse(effect, null);
+    // THEN
+    expect(s).toEqual('15% de chance de contrer les dégâts physiques par: ' +
+      '<a href="ffexvius_skills.php?gumiid=509624">Lame des braves (FFV)</a>');
+  });
+
   it('should parse multi-skill when effect is the only one', () => {
     // GIVEN
     const skills = JSON.parse(ABILITY_SKILLS_TEST_DATA);

--- a/src/app/ffbe/mappers/effects/passives/passive-counter-attack-with-skill.parser.ts
+++ b/src/app/ffbe/mappers/effects/passives/passive-counter-attack-with-skill.parser.ts
@@ -3,6 +3,7 @@ import {Skill} from '../../../model/skill.model';
 import {SkillsService} from '../../../services/skills.service';
 import {SkillMapper} from '../../skill-mapper';
 import {HTML_LINE_RETURN} from '../skill-effects.mapper';
+import {FfbeUtils} from '../../../utils/ffbe-utils';
 
 export class PassiveCounterAttackWithSkillParser extends EffectParser {
   public parse(effect: Array<any>, skill: Skill): string {
@@ -26,9 +27,15 @@ export class PassiveCounterAttackWithSkillParser extends EffectParser {
     }
 
     activatedSkill.isActivatedByPassiveSkill = true;
-    return SkillMapper.toCompetence(activatedSkill).effet_fr
-      .split(HTML_LINE_RETURN)
-      .map(effet => `${prefixText}${effet}${suffixText}`)
-      .join(HTML_LINE_RETURN);
+    const activatedCompetence = SkillMapper.toCompetence(activatedSkill);
+
+    if (!FfbeUtils.isNullOrUndefined(activatedCompetence.hits) && activatedCompetence.hits >= 5) {
+      return `${prefixText}${this.getSkillNameWithGumiIdentifierLink(activatedSkill)}${suffixText}`;
+    } else {
+      return activatedCompetence.effet_fr
+        .split(HTML_LINE_RETURN)
+        .map(effet => `${prefixText}${effet}${suffixText}`)
+        .join(HTML_LINE_RETURN);
+    }
   }
 }


### PR DESCRIPTION
Passive skills that activate counter-attacks with 5 hits or more now indicate the link to the activated skill.