### PR TITLE
Fixed handling of weapon damage variance

### DIFF
--- a/src/app/ffbe/mappers/equipment-mapper.ts
+++ b/src/app/ffbe/mappers/equipment-mapper.ts
@@ -40,11 +40,11 @@ export class EquipmentMapper {
     objet.resistancesElementaires = resistancesElementaires;
     objet.elementsArme = elementsArme;
 
-    if (equipment.is_twohanded && equipment.dmg_variance.length >= 2) {
+    objet.two_handed = equipment.is_twohanded;
+    if (Array.isArray(equipment.dmg_variance) && equipment.dmg_variance.length >= 2) {
       objet.variance_min = Math.round(equipment.dmg_variance[0] * 100);
       objet.variance_max = Math.round(equipment.dmg_variance[1] * 100);
     }
-
     objet.alterationsArme = EquipmentMapper.mapEquipmentStatusEffect(equipment.stats.status_inflict);
 
     return objet;

--- a/src/app/ffbe/model/objet/objet.model.ts
+++ b/src/app/ffbe/model/objet/objet.model.ts
@@ -13,6 +13,7 @@ export class Objet {
   public resistancesElementaires: ObjetElements;
   public elementsArme: ObjetElements;
   public alterationsArme;
+  public two_handed;
   public variance_min: number;
   public variance_max: number;
 
@@ -57,6 +58,10 @@ export class Objet {
       ObjetElements.produce(o.elements),
       ObjetAlterationsEtat.produce(o.resistancesAlterations),
       o.competences);
+    objet.two_handed = o.two_handed;
+    if (objet.isWeapon() && FfbeUtils.isNullOrUndefined(objet.two_handed)) {
+      objet.two_handed = false;
+    }
     objet.variance_min = o.variance_min;
     objet.variance_max = o.variance_max;
     objet.lienTMR = ObjetLienTMR.produce(o.lienTMR);
@@ -71,7 +76,11 @@ export class Objet {
     return !FfbeUtils.isNullOrUndefined(this.icone);
   }
 
-  public isTwoHanded(): boolean {
+  public hasVariance(): boolean {
     return !FfbeUtils.isNullOrUndefined(this.variance_min) && !FfbeUtils.isNullOrUndefined(this.variance_max);
+  }
+
+  public isWeapon(): boolean {
+    return (!FfbeUtils.isNullOrUndefined(this.categorie) && this.categorie.gumiId > 0 && this.categorie.gumiId <= 16);
   }
 }

--- a/src/app/ffbe/objet-display/objet-display.component.html
+++ b/src/app/ffbe/objet-display/objet-display.component.html
@@ -38,7 +38,15 @@
         <th>Stars</th>
         <td>{{objet.stars}}</td>
       </tr>
-      <tr *ngIf="objet.isTwoHanded()">
+      <tr *ngIf="objet.isWeapon()">
+        <th>
+          Arme
+        </th>
+        <td>
+          {{objet.two_handed ? '2 mains' : '1 main'}}
+        </td>
+      </tr>
+      <tr *ngIf="objet.hasVariance()">
         <th>
           Variance
         </th>

--- a/src/php/classes.php
+++ b/src/php/classes.php
@@ -117,6 +117,7 @@ class Objet
   public $caracp;
   public $elements;
   public $resistancesAlterations;
+  public $two_handed;
   public $variance_min;
   public $variance_max;
   public $competences;
@@ -137,6 +138,9 @@ class Objet
     $this->caracp = new ObjetCarac($brex_objet->pvp, $brex_objet->pmp, $brex_objet->attp, $brex_objet->defp, $brex_objet->magp, $brex_objet->psyp);
     $this->elements = new ObjetElement($brex_objet->res_feu, $brex_objet->res_glace, $brex_objet->res_foudre, $brex_objet->res_eau, $brex_objet->res_air, $brex_objet->res_terre, $brex_objet->res_lumiere, $brex_objet->res_tenebres);
     $this->resistancesAlterations = new ObjetAlterationsEtat($brex_objet->res_poison, $brex_objet->res_cecite, $brex_objet->res_sommeil, $brex_objet->res_mutisme, $brex_objet->res_paralysie, $brex_objet->res_confusion, $brex_objet->res_maladie, $brex_objet->res_petrification);
+    if (!is_null($brex_objet->two_handed)) {
+      $this->two_handed = $brex_objet->two_handed ? true : false;
+    }
     $this->variance_min = $brex_objet->variance_min;
     $this->variance_max = $brex_objet->variance_max;
 

--- a/src/php/objects.php
+++ b/src/php/objects.php
@@ -145,6 +145,8 @@ function createAndValidateObjet($objet)
   $values ['res_maladie'] = $objet->resistancesAlterations->maladie;
   $values ['res_petrification'] = $objet->resistancesAlterations->petrification;
 
+  if (isset ($objet->two_handed))
+    $values ['two_handed'] = ($objet->two_handed == true) ? '1' : '0';
   if (property_exists($objet, 'variance_min')) $values ['variance_min'] = $objet->variance_min;
   if (property_exists($objet, 'variance_max')) $values ['variance_max'] = $objet->variance_max;
 


### PR DESCRIPTION
Fixes #98 :
Weapons can now have damage variance, even if they are one-handed.