### PR TITLE
Fixing a wrong parsing of passive killer effects when applying the same value to several monster types

### DIFF
--- a/src/app/ffbe/mappers/effects/passive-effect-parser.factory.spec.ts
+++ b/src/app/ffbe/mappers/effects/passive-effect-parser.factory.spec.ts
@@ -70,6 +70,10 @@ describe('PassiveEffectParser', () => {
       parsed: '50% de chance de protéger un allié féminin des attaques physiques avec mitigation de 40%-60%'
     },
     {effect: '[0, 3, 9, [100]]', parsed: '+100% d\'efficacité des objets de soin en combat'},
+    {
+      effect: '[0, 3, 11, [[4,  6], 50, 0]]',
+      parsed: '+50% de dégâts physiques contre les démons' + HTML_LINE_RETURN + '+50% de dégâts physiques contre les machines'
+    },
     {effect: '[0, 3, 11, [1, 50, 50]]', parsed: '+50% de dégâts physiques et magiques contre les bêtes'},
     {
       effect: '[0, 3, 11, [5, 50, 100]]',

--- a/src/app/ffbe/mappers/effects/passives/passive-killer-damage-increase.parser.ts
+++ b/src/app/ffbe/mappers/effects/passives/passive-killer-damage-increase.parser.ts
@@ -10,26 +10,26 @@ export class PassiveKillerDamageIncreaseParser extends EffectParser {
     }
 
     const monsterTypeGumiIds = Array.isArray(effect[3][0]) ? effect[3][0] : [effect[3][0]];
-    const physicalDamageIncreases = Array.isArray(effect[3][1]) ? effect[3][1] : [effect[3][1]];
-    const magicalDamageIncreases = Array.isArray(effect[3][2]) ? effect[3][2] : [effect[3][2]];
+    const physicalDamageIncreases = Array.isArray(effect[3][1]) ? effect[3][1] : Array(monsterTypeGumiIds.length).fill(effect[3][1]);
+    const magicalDamageIncreases = Array.isArray(effect[3][2]) ? effect[3][2] : Array(monsterTypeGumiIds.length).fill(effect[3][2]);
 
     const texts: Array<string> = [];
     monsterTypeGumiIds.forEach((monsterTypeGumiId, index) => {
       let text = '';
       const monsterType = FFBE_MONSTER_TYPES.find(type => type.gumiId === monsterTypeGumiId);
-      const monsterTypeText = 'contre les ' + (monsterType ? monsterType.pluralName : 'UNKNOWN');
+      const monsterTypeText = `contre les ${monsterType ? monsterType.pluralName : 'UNKNOWN'}`;
       const physicalDamageIncrease = physicalDamageIncreases.length > index ? physicalDamageIncreases[index] : 0;
       const magicalDamageIncrease = magicalDamageIncreases.length > index ? magicalDamageIncreases[index] : 0;
 
       if (physicalDamageIncrease > 0) {
-        text += '+' + physicalDamageIncrease + '% de dégâts physiques ';
+        text += `+${physicalDamageIncrease}% de dégâts physiques `;
         if (magicalDamageIncrease > 0 && physicalDamageIncrease === magicalDamageIncrease) {
           text += 'et magiques ';
         }
         text += monsterTypeText;
       }
       if (magicalDamageIncrease > 0 && physicalDamageIncrease !== magicalDamageIncrease) {
-        text += (text.length ? HTML_LINE_RETURN : '') + '+' + magicalDamageIncrease + '% de dégâts magiques ' + monsterTypeText;
+        text += `${text.length ? HTML_LINE_RETURN : ''}+${magicalDamageIncrease}% de dégâts magiques ${monsterTypeText}`;
       }
       texts.push(text);
     });


### PR DESCRIPTION
 Fixes #157