### PR TITLE
#212: Missing case in the AbilityEnemyScanParser

### DIFF
--- a/src/app/ffbe/mappers/effects/abilities/ability-enemy-scan.parser.ts
+++ b/src/app/ffbe/mappers/effects/abilities/ability-enemy-scan.parser.ts
@@ -3,7 +3,8 @@ import {Skill} from '../../../model/skill.model';
 
 export class AbilityEnemyScanParser extends EffectParser {
   parse(effect: Array<any>, skill: Skill): string {
-    if (effect.length < 4 || !Array.isArray(effect[3]) || effect[3].length < 1 || effect[3][0] !== 134) {
+    if (effect.length < 4 || !Array.isArray(effect[3]) || effect[3].length < 1 ||
+      (effect[3][0] !== 0 && effect[3][0] !== 134)) {
       return 'Effet AbilityEnemyScanParser inconnu: Mauvaise liste de paramètres';
     }
 


### PR DESCRIPTION
Fixes #212 