### PR TITLE
#237: Fixed the number of turns for skills enabled at the start of battle

### DIFF
--- a/src/app/ffbe/mappers/effects/abilities/ability-skill-activation.parser.spec.ts
+++ b/src/app/ffbe/mappers/effects/abilities/ability-skill-activation.parser.spec.ts
@@ -24,7 +24,7 @@ describe('AbilitySkillActivationParser', () => {
     SkillsService['INSTANCE'] = skillsServiceMock;
     const mySpy = spyOn(skillsServiceMock, 'searchForSkillByGumiId').and.returnValues(Skill.produce(skill));
     // WHEN
-    const s = AbilityEffectParserFactory.getParser(effect[0], effect[1], effect[2]).parse(effect, null);
+    const s = AbilityEffectParserFactory.getParser(effect[0], effect[1], effect[2]).parse(effect, skill);
     // THEN
     expect(mySpy).toHaveBeenCalledTimes(1);
     expect(mySpy).toHaveBeenCalledWith(200200);
@@ -46,7 +46,7 @@ describe('AbilitySkillActivationParser', () => {
     SkillsService['INSTANCE'] = skillsServiceMock;
     const mySpy = spyOn(skillsServiceMock, 'searchForSkillByGumiId').and.returnValues(Skill.produce(skill));
     // WHEN
-    const s = AbilityEffectParserFactory.getParser(effect[0], effect[1], effect[2]).parse(effect, null);
+    const s = AbilityEffectParserFactory.getParser(effect[0], effect[1], effect[2]).parse(effect, skill);
     // THEN
     expect(mySpy).toHaveBeenCalledTimes(1);
     expect(mySpy).toHaveBeenCalledWith(200200);
@@ -71,7 +71,7 @@ describe('AbilitySkillActivationParser', () => {
     skill3.gumi_id = 202340;
     skill3.names = names['202340'];
     skill3.descriptions = descriptions['202340'];
-
+    const skill: Skill = new Skill();
 
     const effect = JSON.parse('[0, 3, 100, [[2,  2,  2], [200200, 200270, 202340], 9999, 4, 1, 0]]');
     const skillsServiceMock = new SkillsServiceMock() as SkillsService;
@@ -79,7 +79,7 @@ describe('AbilitySkillActivationParser', () => {
     const mySpy = spyOn(skillsServiceMock, 'searchForSkillByGumiId')
       .and.returnValues(Skill.produce(skill1), Skill.produce(skill2), Skill.produce(skill3));
     // WHEN
-    const s = AbilityEffectParserFactory.getParser(effect[0], effect[1], effect[2]).parse(effect, null);
+    const s = AbilityEffectParserFactory.getParser(effect[0], effect[1], effect[2]).parse(effect, skill);
     // THEN
     expect(mySpy).toHaveBeenCalledTimes(3);
     expect(mySpy).toHaveBeenCalledWith(200200);
@@ -105,7 +105,7 @@ describe('AbilitySkillActivationParser', () => {
     SkillsService['INSTANCE'] = skillsServiceMock;
     const mySpy = spyOn(skillsServiceMock, 'searchForSkillByGumiId').and.returnValues(Skill.produce(skill));
     // WHEN
-    const s = AbilityEffectParserFactory.getParser(effect[0], effect[1], effect[2]).parse(effect, null);
+    const s = AbilityEffectParserFactory.getParser(effect[0], effect[1], effect[2]).parse(effect, skill);
     // THEN
     expect(mySpy).toHaveBeenCalledTimes(1);
     expect(mySpy).toHaveBeenCalledWith(200200);
@@ -127,7 +127,7 @@ describe('AbilitySkillActivationParser', () => {
     SkillsService['INSTANCE'] = skillsServiceMock;
     const mySpy = spyOn(skillsServiceMock, 'searchForSkillByGumiId').and.returnValues(Skill.produce(skill));
     // WHEN
-    const s = AbilityEffectParserFactory.getParser(effect[0], effect[1], effect[2]).parse(effect, null);
+    const s = AbilityEffectParserFactory.getParser(effect[0], effect[1], effect[2]).parse(effect, skill);
     // THEN
     expect(mySpy).toHaveBeenCalledTimes(1);
     expect(mySpy).toHaveBeenCalledWith(200200);
@@ -149,7 +149,7 @@ describe('AbilitySkillActivationParser', () => {
     SkillsService['INSTANCE'] = skillsServiceMock;
     const mySpy = spyOn(skillsServiceMock, 'searchForSkillByGumiId').and.returnValues(Skill.produce(skill));
     // WHEN
-    const s = AbilityEffectParserFactory.getParser(effect[0], effect[1], effect[2]).parse(effect, null);
+    const s = AbilityEffectParserFactory.getParser(effect[0], effect[1], effect[2]).parse(effect, skill);
     // THEN
     expect(mySpy).toHaveBeenCalledTimes(1);
     expect(mySpy).toHaveBeenCalledWith(200200);
@@ -172,7 +172,7 @@ describe('AbilitySkillActivationParser', () => {
     SkillsService['INSTANCE'] = skillsServiceMock;
     const mySpy = spyOn(skillsServiceMock, 'searchForSkillByGumiId').and.returnValues(Skill.produce(skill));
     // WHEN
-    const s = AbilityEffectParserFactory.getParser(effect[0], effect[1], effect[2]).parse(effect, null);
+    const s = AbilityEffectParserFactory.getParser(effect[0], effect[1], effect[2]).parse(effect, skill);
     // THEN
     expect(mySpy).toHaveBeenCalledTimes(1);
     expect(mySpy).toHaveBeenCalledWith(200200);
@@ -194,7 +194,7 @@ describe('AbilitySkillActivationParser', () => {
     SkillsService['INSTANCE'] = skillsServiceMock;
     const mySpy = spyOn(skillsServiceMock, 'searchForSkillByGumiId').and.returnValues(Skill.produce(skill));
     // WHEN
-    const s = AbilityEffectParserFactory.getParser(effect[0], effect[1], effect[2]).parse(effect, null);
+    const s = AbilityEffectParserFactory.getParser(effect[0], effect[1], effect[2]).parse(effect, skill);
     // THEN
     expect(mySpy).toHaveBeenCalledTimes(1);
     expect(mySpy).toHaveBeenCalledWith(200200);
@@ -216,11 +216,35 @@ describe('AbilitySkillActivationParser', () => {
     SkillsService['INSTANCE'] = skillsServiceMock;
     const mySpy = spyOn(skillsServiceMock, 'searchForSkillByGumiId').and.returnValues(Skill.produce(skill));
     // WHEN
-    const s = AbilityEffectParserFactory.getParser(effect[0], effect[1], effect[2]).parse(effect, null);
+    const s = AbilityEffectParserFactory.getParser(effect[0], effect[1], effect[2]).parse(effect, skill);
     // THEN
     expect(mySpy).toHaveBeenCalledTimes(1);
     expect(mySpy).toHaveBeenCalledWith(200200);
     expect(s).toEqual('Donne accès à <a href="ffexvius_skills.php?gumiid=200200">Coup de pied</a> aux alliés pour 1 utilisation sur 4 tours');
+  });
+
+  it('should parse skill activation for caster for the current turn when activated by passive skill', () => {
+    // GIVEN
+    const skills = JSON.parse(ABILITY_SKILLS_TEST_DATA);
+    const names = JSON.parse(ABILITY_SKILLS_NAMES_TEST_DATA);
+    const descriptions = JSON.parse(ABILITY_SKILLS_SHORTDESCRIPTIONS_TEST_DATA);
+
+    const skill: Skill = skills['512170'];
+    skill.gumi_id = 512170;
+    skill.names = names['512170'];
+    skill.descriptions = descriptions['512170'];
+    skill.isActivatedByPassiveSkill = true;
+
+    const effect = JSON.parse('[0, 3, 100, [2,  512170,  99999,  1,  1,  5]]');
+    const skillsServiceMock = new SkillsServiceMock() as SkillsService;
+    SkillsService['INSTANCE'] = skillsServiceMock;
+    const mySpy = spyOn(skillsServiceMock, 'searchForSkillByGumiId').and.returnValues(Skill.produce(skill));
+    // WHEN
+    const s = AbilityEffectParserFactory.getParser(effect[0], effect[1], effect[2]).parse(effect, skill);
+    // THEN
+    expect(mySpy).toHaveBeenCalledTimes(1);
+    expect(mySpy).toHaveBeenCalledWith(512170);
+    expect(s).toEqual('Donne accès à <a href="ffexvius_skills.php?gumiid=512170">Point faible + : Feu</a> au lanceur pour 1 tour');
   });
 });
 

--- a/src/app/ffbe/mappers/effects/abilities/ability-skill-activation.parser.ts
+++ b/src/app/ffbe/mappers/effects/abilities/ability-skill-activation.parser.ts
@@ -13,7 +13,7 @@ export class AbilitySkillActivationParser extends EffectParser {
     const target = this.getTarget(effect[0], effect[1]);
 
     const numUses = this.getNumUses(content);
-    const numTurns = this.getNumTurns(content, isTargetSelf);
+    const numTurns = this.getNumTurns(content, isTargetSelf, skill.isActivatedByPassiveSkill);
     const activatedSkillsIds: Array<number> = !Array.isArray(effect[3][1]) ? [effect[3][1]] : effect[3][1];
 
     const activatedSkills = activatedSkillsIds.map((skillId: number) => SkillsService.getInstance().searchForSkillByGumiId(skillId));
@@ -48,8 +48,8 @@ export class AbilitySkillActivationParser extends EffectParser {
     return effect[1] === 3;
   }
 
-  private getNumTurns(content: Array<any>, isTargetSelf: boolean): string {
-    const numTurns = isTargetSelf ? content[3] - 1 : content[3];
+  private getNumTurns(content: Array<any>, isTargetSelf: boolean, isActivatedByPassiveSkill: boolean): string {
+    const numTurns = isTargetSelf && !isActivatedByPassiveSkill ? content[3] - 1 : content[3];
     const pluralForm = numTurns > 1 ? 's' : '';
     return `${numTurns} tour${pluralForm}`;
   }

--- a/src/app/ffbe/model/skill.model.spec.ts
+++ b/src/app/ffbe/model/skill.model.spec.ts
@@ -657,6 +657,30 @@ export const ABILITY_SKILLS_TEST_DATA =
         "effects_raw": [[2, 1, 15, [0,  0,  0,  0,  0,  400,  0]], [2, 1, 72, [0,  0,  700,  500,  500,  7]]],
         "requirements": null,
         "unit_restriction": null
+    },
+    "512170": {
+        "name": "True Fire Achilles",
+        "icon": "ability_39.png",
+        "compendium_id": 10982,
+        "rarity": 8,
+        "cost": {"MP": 66},
+        "attack_count": [1],
+        "attack_damage": [[100]],
+        "attack_frames": [[40]],
+        "effect_frames": [[6,  6,  6,  6,  6]],
+        "move_type": 4,
+        "motion_type": 2,
+        "effect_type": "Default",
+        "attack_type": "Physical",
+        "element_inflict": null,
+        "effects": [
+            "Reduce resistance to Fire by 130% for 3 turns to one enemy",
+            "Physical damage (22x, ATK) to one enemy",
+            "Gain True Fire Achilles (512170) for 2 turns"
+        ],
+        "effects_raw": [[1, 1, 33, [-130,  0,  0,  0,  0,  0,  0,  0,  1,  3]], [1, 1, 1, [0,  0,  0,  0,  0,  0,  2200,  0]], [0, 3, 100, [2,  512170,  99999,  3,  1,  5]]],
+        "requirements": null,
+        "unit_restriction": null
     }
   }`;
 
@@ -825,6 +849,15 @@ export const ABILITY_SKILLS_NAMES_TEST_DATA =
         "Magilame des tempêtes",
         "Sturmschwertmagie",
         "Esgrimago tempestuoso"
+    ],
+    "512170": [
+        "True Fire Achilles",
+        "真·火之要害",
+        "진·불의 아킬레스",
+        "Point faible + : Feu",
+        "Wahrer Feuer-Achilles",
+        "Aquiles de fuego verdadero",
+        "Achilles Api Sejati"
     ]
   }`;
 
@@ -993,7 +1026,16 @@ export const ABILITY_SKILLS_SHORTDESCRIPTIONS_TEST_DATA =
         "Inflige des dégâts de foudre et de vent à tous les ennemis",
         "Fügt allen Gegnern Blitz- und Windschaden zu.",
         "Daño de rayo y viento a todos los enemigos"
-    ]
+    ],
+    "512170": [
+        "Reduce fire resistance and damage one enemy, and enable true fire achilles for two turns",
+        "降低1名敵人的火屬性耐性+發動攻擊+2回合內可使用「真·火之要害」",
+        "적 1명의 불속성 저항력 감소+피해+2턴 동안 '진·불의 아킬레스' 사용 가능",
+        "Réduit la résistance au feu d'un ennemi et lui inflige des dégâts, et permet d'utiliser Point faible + : Feu pendant 2 tours",
+        "Verringert die Feuerresistenz eines Gegners, fügt ihm Schaden zu und ermöglicht 2 Runden lang Wahrer Feuer-Achilles.",
+        "Reduce la resistencia al fuego, daña a un enemigo y aprende Aquiles de fuego verdadero durante 2 turnos",
+        "Mengurangi resistansi api dan memberikan damage pada satu musuh, serta memungkinkan penggunaan Achilles Api Sejati selama 2 giliran"
+     ]
   }`;
 
 describe('Skill', () => {


### PR DESCRIPTION
Fixes #237 

Since these skills become available at the beginning of the turn, the turn computation had to be adjusted.