### PR TITLE
#348: Added parser for Magnus skills of GLEX units

### DIFF
--- a/src/app/ffbe/mappers/skill-mapper.ts
+++ b/src/app/ffbe/mappers/skill-mapper.ts
@@ -51,15 +51,25 @@ export class SkillMapper {
     );
   }
 
+  private static orderSkillEffectsRaw(skill: Skill) {
+    skill.effects_raw?.sort((effect1, effect2) => SkillMapper.compareTwoSkillEffectsByIds(effect1[2], effect2[2]));
+  }
+
   // effect 132 is for delayed skills but might appear in the data mining before another effect which is activated immediately
   // to avoid confusion, need to move the delayed skills at the end of the table
   // effect 1014 is for GLEX magnus skills, whose effect should be stated first
-  private static orderSkillEffectsRaw(skill: Skill) {
-    skill.effects_raw?.sort(
-      (effect1, effect2) => effect1[2] === 132 && effect2[2] !== 132 ? 1 :
-        (effect1[2] !== 132 && effect2[2] === 132 ? -1 :
-          (effect1[2] === 1014 && effect2[2] !== 1014 ? -1 : (effect1[2] !== 1014 && effect2[2] === 1014 ? 1 : 0)
-          )));
+  private static compareTwoSkillEffectsByIds(skillEffectId1: number, skillEffectId2: number): number {
+    let result = 0;
+    if (skillEffectId1 === 132 && skillEffectId2 !== 132) {
+      result = 1;
+    } else if (skillEffectId1 !== 132 && skillEffectId2 === 132) {
+      result = -1;
+    } else if (skillEffectId1 === 1014 && skillEffectId2 !== 1014) {
+      result = -1;
+    } else if (skillEffectId1 !== 1014 && skillEffectId2 === 1014) {
+      result = 1;
+    }
+    return result;
   }
 
   public static mapHitsFramesAndDamages(skill: Skill): { hits: number, frames: string, damages: string } {

--- a/src/app/ffbe/mappers/skill-mapper.ts
+++ b/src/app/ffbe/mappers/skill-mapper.ts
@@ -53,10 +53,13 @@ export class SkillMapper {
 
   // effect 132 is for delayed skills but might appear in the data mining before another effect which is activated immediately
   // to avoid confusion, need to move the delayed skills at the end of the table
+  // effect 1014 is for GLEX magnus skills, whose effect should be stated first
   private static orderSkillEffectsRaw(skill: Skill) {
     skill.effects_raw?.sort(
-      (effect1, effect2) => effect1[2] === 132 && effect2[2] !== 132 ? 1 : (effect1[2] !== 132 && effect2[2] === 132 ? -1 : 0)
-    );
+      (effect1, effect2) => effect1[2] === 132 && effect2[2] !== 132 ? 1 :
+        (effect1[2] !== 132 && effect2[2] === 132 ? -1 :
+          (effect1[2] === 1014 && effect2[2] !== 1014 ? -1 : (effect1[2] !== 1014 && effect2[2] === 1014 ? 1 : 0)
+          )));
   }
 
   public static mapHitsFramesAndDamages(skill: Skill): { hits: number, frames: string, damages: string } {

--- a/src/app/ffbe/model/effects/abilities/skill/ability-skill-magnus-glex-effect.model.spec.ts
+++ b/src/app/ffbe/model/effects/abilities/skill/ability-skill-magnus-glex-effect.model.spec.ts
@@ -1,0 +1,85 @@
+import {
+  ABILITY_SKILLS_NAMES_TEST_DATA,
+  ABILITY_SKILLS_TEST_DATA
+} from '../../../skill.model.spec';
+import {Skill} from '../../../skill.model';
+import {SkillsService} from '../../../../services/skills.service';
+import {SkillsServiceMock} from '../../../../services/skills.service.spec';
+import {SkillMapper} from '../../../../mappers/skill-mapper';
+
+describe('AbilitySkillMagnusGlexEffect', () => {
+  it('should parse GLEX magnus skills', () => {
+    // GIVEN
+    const skills = JSON.parse(ABILITY_SKILLS_TEST_DATA);
+
+    const rawMagnusSkill: Skill = skills['913625'];
+    rawMagnusSkill.gumi_id = 913625;
+    rawMagnusSkill.active = true;
+    const magnusSkill = Skill.produce(rawMagnusSkill);
+
+    // WHEN
+    const competence = SkillMapper.toCompetence(magnusSkill);
+
+    // THEN
+    expect(competence.effet).toEqual('<strong>1 utilisation par combat</strong>:<br />+100 cristaux de limite aux alliés sauf le lanceur');
+  });
+
+  it('should parse GLEX magnus skills with per-turn usage restriction', () => {
+    // GIVEN
+    const skills = JSON.parse(ABILITY_SKILLS_TEST_DATA);
+    const names = JSON.parse(ABILITY_SKILLS_NAMES_TEST_DATA);
+
+    const rawMagnusSkill: Skill = skills['913881'];
+    rawMagnusSkill.gumi_id = 913881;
+    rawMagnusSkill.names = names['913881'];
+    rawMagnusSkill.active = true;
+
+    const activatedSkill: Skill = skills['913897'];
+    activatedSkill.gumi_id = 913897;
+    activatedSkill.names = names['913897'];
+    activatedSkill.active = true;
+
+    const skillsServiceMock = new SkillsServiceMock() as SkillsService;
+    SkillsService['INSTANCE'] = skillsServiceMock;
+    const mySpy = spyOn(skillsServiceMock, 'searchForSkillByGumiId').and.returnValues(Skill.produce(activatedSkill), Skill.produce(activatedSkill));
+
+    const magnusSkill = Skill.produce(rawMagnusSkill);
+
+    // WHEN
+    const competence = SkillMapper.toCompetence(magnusSkill);
+
+    // THEN
+    expect(mySpy).toHaveBeenCalledTimes(2);
+    expect(mySpy).toHaveBeenCalledWith(913897);
+    expect(competence.effet).toEqual('<strong>2 utilisations par combat</strong>:<br />'
+      + 'Disponible tous les 5 tours dès le tour 5:<br />' +
+      'Dégâts physiques neutres de puissance 2000% avec sacrifice de 51% des PV du lanceur aux adversaires<br />' +
+      'Dégâts physiques neutres de puissance 2000% (ignore 50% DÉF, 4000% total) aux adversaires (ignore les couvertures)<br />' +
+      '+10 esquives physiques au lanceur pour 3 tours<br />' +
+      '100% de chance pour le lanceur de contrer les dégâts physiques par une attaque de puissance 1000% pour 3 tours (max 5 par tour)'
+    );
+    expect(competence.puissance).toEqual(6000);
+
+    expect(magnusSkill.attack_count.length).toEqual(2);
+    expect(magnusSkill.attack_count[0]).toEqual(9);
+    expect(magnusSkill.attack_count[1]).toEqual(1);
+
+    expect(magnusSkill.attack_frames.length).toEqual(2);
+    expect(magnusSkill.attack_frames[0].length).toEqual(9);
+    expect(magnusSkill.attack_frames[0][0]).toEqual(110);
+    expect(magnusSkill.attack_frames[0][1]).toEqual(120);
+    expect(magnusSkill.attack_frames[0][8]).toEqual(190);
+    expect(magnusSkill.attack_frames[1].length).toEqual(1);
+    expect(magnusSkill.attack_frames[1][0]).toEqual(200);
+
+    expect(magnusSkill.attack_damage.length).toEqual(2);
+    expect(magnusSkill.attack_damage[0].length).toEqual(9);
+    expect(magnusSkill.attack_damage[0][0]).toEqual(11);
+    expect(magnusSkill.attack_damage[0][1]).toEqual(11);
+    expect(magnusSkill.attack_damage[1].length).toEqual(1);
+    expect(magnusSkill.attack_damage[1][0]).toEqual(100);
+    expect(magnusSkill.attack_type).toEqual('Physical');
+    expect(magnusSkill.physique).toBeTruthy();
+  });
+
+});

--- a/src/app/ffbe/model/effects/abilities/skill/ability-skill-magnus-glex-effect.model.ts
+++ b/src/app/ffbe/model/effects/abilities/skill/ability-skill-magnus-glex-effect.model.ts
@@ -1,0 +1,31 @@
+import {Skill} from '../../../skill.model';
+import {TargetNumberEnum} from '../../target-number.enum';
+import {TargetTypeEnum} from '../../target-type.enum';
+import {SkillEffect} from '../../skill-effect.model';
+
+export class AbilitySkillMagnusGlexEffect extends SkillEffect {
+
+  private activationLimit: number;
+
+  constructor(protected targetNumber: TargetNumberEnum,
+              protected targetType: TargetTypeEnum,
+              protected effectId: number,
+              protected parameters: Array<any>) {
+    super(targetNumber, targetType, effectId);
+    if (!Array.isArray(parameters) || parameters.length < 6 || parameters[1] !== 2 ||
+      parameters[4] !== 1 || parameters[5] !== 0 || (parameters[2] !== parameters[3])) {
+      this.parameterError = true;
+    } else {
+      this.activationLimit = parameters[2];
+    }
+  }
+
+  protected wordEffectImpl(skill: Skill) {
+    const pluralSuffix = this.activationLimit > 1 ? 's' : '';
+    return `<strong>${this.activationLimit} utilisation${pluralSuffix} par combat</strong>:`;
+  }
+
+  protected get effectName(): string {
+    return 'AbilitySkillMagnusGlexEffect';
+  }
+}

--- a/src/app/ffbe/model/effects/ability-skill-effect.factory.ts
+++ b/src/app/ffbe/model/effects/ability-skill-effect.factory.ts
@@ -32,6 +32,7 @@ import {AbilityDamagePhysicalIncreasedModifierEnemyTypeEffect} from './abilities
 import {AbilitySkillActivationEffect} from './abilities/skill/ability-skill-activation-effect.model';
 import {AbilitySkillRandomEffect} from './abilities/skill/ability-skill-random-effect.model';
 import {AbilityWeaponTypeWielderDamageIncreaseEffect} from './abilities/ability-weapon-type-wielder-damage-increase-effect.model';
+import {AbilitySkillMagnusGlexEffect} from './abilities/skill/ability-skill-magnus-glex-effect.model';
 
 export class AbilitySkillEffectFactory {
   public static getSkillEffect(effectRaw): SkillEffect {
@@ -112,6 +113,8 @@ export class AbilitySkillEffectFactory {
         return new AbilityWeaponTypeWielderDamageIncreaseEffect(effectRaw[0], effectRaw[1], effectRaw[2], effectRaw[3]);
       case 1012:
         return new AbilityDamageHexEffect(effectRaw[0], effectRaw[1], effectRaw[2], effectRaw[3]);
+      case 1014:
+        return new AbilitySkillMagnusGlexEffect(effectRaw[0], effectRaw[1], effectRaw[2], effectRaw[3]);
       default:
         return null;
     }

--- a/src/app/ffbe/model/skill.model.spec.ts
+++ b/src/app/ffbe/model/skill.model.spec.ts
@@ -1225,6 +1225,77 @@ export const ABILITY_SKILLS_TEST_DATA =
         "effects_raw": [[2, 1, 33, [-50,  -50,  -50,  -50,  -50,  -50,  -50,  -50,  1,  1]]],
         "requirements": null,
         "unit_restriction": null
+    },
+    "913625": {
+        "name": "Celestial Destiny",
+        "icon": "global_ability_10101.png",
+        "compendium_id": 86977,
+        "rarity": 10,
+        "cost": {"MP": 200, "EP": 10},
+        "attack_count": [0],
+        "attack_damage": [[]],
+        "attack_frames": [[]],
+        "effect_frames": [[1,  1]],
+        "move_type": 4,
+        "motion_type": 2,
+        "effect_type": "Default",
+        "attack_type": "None",
+        "element_inflict": null,
+        "effects": [
+            "Increase LB gauge by 100 to the rest of the party",
+            "Unknown active effect type '1014': [913625,2,1,1,1,0]"
+        ],
+        "effects_raw": [[2, 5, 125, [10000,  10000]], [0, 3, 1014, [913625,  2,  1,  1,  1,  0]]],
+        "requirements": null,
+        "unit_restriction": null
+    },
+    "913881": {
+        "name": "Uroboros of Wrath",
+        "icon": "global_ability_10101.png",
+        "compendium_id": 87227,
+        "rarity": 9,
+        "cost": {"MP": 100},
+        "attack_count": [0],
+        "attack_damage": [[]],
+        "attack_frames": [[]],
+        "effect_frames": [[]],
+        "move_type": 4,
+        "motion_type": 2,
+        "effect_type": "Default",
+        "attack_type": "Physical",
+        "element_inflict": null,
+        "effects": [
+            "Unlock Uroboros of Wrath (913897) on turn 5 [5 turns CD]",
+            "Unknown active effect type '1014': [913881,2,2,2,1,0]"
+        ],
+        "effects_raw": [[0, 3, 130, [913897, 0, [4,  0], 1]], [0, 3, 1014, [913881,  2,  2,  2,  1,  0]]],
+        "requirements": null,
+        "unit_restriction": null
+    },
+    "913897": {
+        "name": "Uroboros of Wrath",
+        "icon": "global_ability_10101.png",
+        "compendium_id": 87243,
+        "rarity": 9,
+        "cost": {"MP": 100},
+        "attack_count": [9, 1],
+        "attack_damage": [[11,  11,  11,  11,  11,  11,  11,  11,  12], [100]],
+        "attack_frames": [[110,  120,  130,  140,  150,  160,  170,  180,  190], [200]],
+        "effect_frames": [[40,  30,  40,  0], [40]],
+        "move_type": 4,
+        "motion_type": 2,
+        "effect_type": "Default",
+        "attack_type": "Physical",
+        "element_inflict": null,
+        "effects": [
+            "Sacrifice 51% HP to deal physical damage (20x, ATK) to all enemies",
+            "Physical damage (20x * 2 = 40x, ATK) to all enemies (ignore cover)",
+            "Dodge 10 physical attacks for 3 turns to caster",
+            "100% chance to counter physical attacks (10x, ATK) to caster for 3 turns (max 5 / turn)"
+        ],
+        "effects_raw": [[2, 1, 81, [0,  0,  0,  0,  0,  0,  2000,  51,  2000315,  1]], [2, 1, 21, [0,  0,  2000,  -50]], [0, 3, 54, [10,  3,  1]], [0, 3, 119, [100,  1,  1000,  3,  1,  5]]],
+        "requirements": null,
+        "unit_restriction": null
     }
   }`;
 
@@ -1442,6 +1513,33 @@ export const ABILITY_SKILLS_NAMES_TEST_DATA =
         "Lance siphon",
         "Soglanze",
         "Lanza sifón"
+    ],
+    "913625": [
+        "Celestial Destiny",
+        "天之宿命",
+        "천명",
+        "Destiné céleste",
+        "Himmlisches Schicksal",
+        "Destino celestial",
+        "Takdir Surgawi"
+    ],
+    "913881": [
+        "Uroboros of Wrath",
+        "拉斯之銜尾蛇",
+        "분노의 우로보로스",
+        "Ouroboros de Wrath",
+        "Uroboros des Zorns",
+        "Uróboros de Ira",
+        "Uroboros Kemarahan"
+    ],
+    "913897": [
+        "Uroboros of Wrath",
+        "拉斯之銜尾蛇",
+        "분노의 우로보로스",
+        "Ouroboros de Wrath",
+        "Uroboros des Zorns",
+        "Uróboros de Ira",
+        "Uroboros Kemarahan"
     ]
   }`;
 


### PR DESCRIPTION
The parser itself is straightforward, but the Magnus effect should appear first in the effect list, so that skill effects should be sorted.