### PR TITLE
#395: Fixed crash when loading new magnus skills

### DIFF
--- a/src/app/ffbe/model/effects/abilities/skill/ability-skill-magnus-effect.model.ts
+++ b/src/app/ffbe/model/effects/abilities/skill/ability-skill-magnus-effect.model.ts
@@ -20,7 +20,7 @@ export class AbilitySkillMagnusEffect extends SkillEffect {
               protected parameters: Array<any>) {
     super(targetNumber, targetType, effectId);
     if (!Array.isArray(parameters) || parameters.length < 9 || parameters[1] !== 1 || parameters[4] !== 1 || parameters[5] !== 1
-      || parameters[6] !== 1 || (parameters[7] !== 0 && parameters[7] !== 1) || (parameters[2] !== parameters[3])) {
+      || (parameters[6] !== 0 && parameters[6] !== 1) || (parameters[7] !== 0 && parameters[7] !== 1) || (parameters[2] !== parameters[3])) {
       this.parameterError = true;
     } else {
       this.activatedSkillId = parameters[0];


### PR DESCRIPTION
The parameter 6 can be either 0 or 1.

Fixes #395 