### PR TITLE
#395: Fixed potential crash for skills with activated skill

### DIFF
--- a/src/app/ffbe/model/effects/abilities/skill/ability-skill-cooldown-effect.model.ts
+++ b/src/app/ffbe/model/effects/abilities/skill/ability-skill-cooldown-effect.model.ts
@@ -51,7 +51,7 @@ export class AbilitySkillCooldownEffect extends SkillEffect {
   }
 
   public getDamagesPower(): number {
-    return this.activatedSkill.calculateSkillPower();
+    return this.parameterError ? 0 : this.activatedSkill?.calculateSkillPower();
   }
 
   public getActivatedSkills(): Array<Skill> {

--- a/src/app/ffbe/model/effects/abilities/skill/ability-skill-magnus-effect.model.ts
+++ b/src/app/ffbe/model/effects/abilities/skill/ability-skill-magnus-effect.model.ts
@@ -44,6 +44,6 @@ export class AbilitySkillMagnusEffect extends SkillEffect {
   }
 
   public getDamagesPower(): number {
-    return this.activatedSkill.calculateSkillPower();
+    return this.parameterError ? 0 : this.activatedSkill?.calculateSkillPower();
   }
 }

--- a/src/app/ffbe/model/effects/abilities/skill/ability-skill-switch-effect.model.ts
+++ b/src/app/ffbe/model/effects/abilities/skill/ability-skill-switch-effect.model.ts
@@ -48,6 +48,6 @@ export class AbilitySkillSwitchEffect extends SkillEffect {
   }
 
   public getDamagesPower(): number {
-    return this.normalSkill.calculateSkillPower();
+    return this.parameterError ? 0 : this.normalSkill?.calculateSkillPower();
   }
 }


### PR DESCRIPTION
The method getDamagesPower() could crash if the activated skill could not be parsed.

Fixes #395 