### PR TITLE
 #268: Fixed crash when fetching Objets with Competences from the bac…

### DIFF
--- a/src/app/ffbe/model/objet/objet.model.ts
+++ b/src/app/ffbe/model/objet/objet.model.ts
@@ -72,7 +72,7 @@ export class Objet implements CaracteristiquesContainer {
       ResistancesAlterations.produce(o.resistancesAlterations),
       o.tueurs,
       o.tueurs_m,
-      o.competences);
+      o.competences.map(competence => Competence.produce(competence)));
 
     objet.extended_gumi_id = o.extended_gumi_id;
     objet.prix_vente = o.prix_vente;


### PR DESCRIPTION
Fixes #268  

 The method Objet::produce() did not clone the Competences.