### PR TITLE
 #326: Fixed wrong parameters in PassiveElementsResistanceParser

### DIFF
--- a/src/app/ffbe/model/effects/passives/passive-elements-resistance-effect.model.ts
+++ b/src/app/ffbe/model/effects/passives/passive-elements-resistance-effect.model.ts
@@ -13,11 +13,14 @@ export class PassiveElementsResistanceEffect extends SkillEffect {
               protected effectId: number,
               protected parameters: Array<any>) {
     super(targetNumber, targetType, effectId);
-    if (!Array.isArray(parameters) || parameters.length < 8) {
+    if (!Array.isArray(parameters) || parameters.length < 1) {
       this.parameterError = true;
     } else {
-      this.increases = new ResistancesElementaires(parameters[0], parameters[1], parameters[2], parameters[3],
-        parameters[4], parameters[5], parameters[6], parameters[7]);
+      if (parameters.length < 8 || parameters.every(parameter => parameter === 0)) {
+        this.parameterWarning = true;
+      }
+      const filler = new Array<number>(8 - parameters.length).fill(0);
+      this.increases = new ResistancesElementaires(... parameters, ... filler);
     }
   }
 

--- a/src/app/ffbe/model/effects/passives/passive-skill-effects.spec.ts
+++ b/src/app/ffbe/model/effects/passives/passive-skill-effects.spec.ts
@@ -20,6 +20,10 @@ describe('PassiveSkillEffect', () => {
     },
     {effect: '[0, 3, 3, [20, 20, 20, 20, 20, 20, 20, 20]]', parsed: '+20% de rés. aux éléments'},
     {
+      effect: '[0, 3, 3, [30,  30,  0,  0,  0,  0,  0]]',
+      parsed: '+30% de rés. Feu, Glace'
+    },
+    {
       effect: '[0, 3, 11, [[4,  6], 50, 0]]',
       parsed: '+50% de dégâts physiques contre les démons' + HTML_LINE_RETURN + '+50% de dégâts physiques contre les machines'
     },


### PR DESCRIPTION
 Pyro Glacial Lasswell has a Passive ElementsResistance SkillEffect with 7 parameters instead of 8 (for the elements).

 Added a filler to the expected parameters so that there are always 8 of them.

Fixes #326 