### PR TITLE
 #435: Fixed crash when loading Enhancements involving a non-existing…

### DIFF
--- a/src/app/ffbe/enhancement-display/enhancement-display.component.ts
+++ b/src/app/ffbe/enhancement-display/enhancement-display.component.ts
@@ -76,9 +76,8 @@ export class EnhancementDisplayComponent implements OnInit, OnChanges {
   }
 
   protected getPersonnages() {
-    this.personnages = [];
-    this.amelioration.units.forEach(unit =>
-      this.personnages.push(CharacterMapper.toPersonnage(this.charactersService.searchForCharacterByGumiId(unit))));
+    this.personnages = this.amelioration.units.map(unit => this.charactersService.searchForCharacterByGumiId(unit))
+      .filter(character => !FfbeUtils.isNullOrUndefined(character)).map(character => CharacterMapper.toPersonnage(character));
     if (this.personnages.length === 1) {
       this.amelioration.perso_gumi_id = this.personnages[0].gumi_id;
     }


### PR DESCRIPTION
… Character

 Lunafreya's Enhancements for Spells are also available for a Character GumiID which doesn't exist yet.

Fixes #435 