### PR TITLE
 #446: Changed parameterErrors into parameterWarnings in PassiveSkill…

### DIFF
--- a/src/app/ffbe/model/effects/abilities/skill/ability-skill-activation-effect.model.spec.ts
+++ b/src/app/ffbe/model/effects/abilities/skill/ability-skill-activation-effect.model.spec.ts
@@ -233,6 +233,7 @@ describe('AbilitySkillActivationEffect', () => {
     skill.gumi_id = 512170;
     skill.names = names['512170'];
     skill.descriptions = descriptions['512170'];
+    skill.active = true;
     skill.isActivatedByPassiveSkill = true;
 
     const effect = JSON.parse('[0, 3, 100, [2,  512170,  99999,  1,  1,  5]]');

--- a/src/app/ffbe/model/effects/passives/passive-skill-replacing-normal-attack-effect.model.ts
+++ b/src/app/ffbe/model/effects/passives/passive-skill-replacing-normal-attack-effect.model.ts
@@ -15,10 +15,10 @@ export class PassiveSkillReplacingNormalAttackEffect extends SkillEffect {
               protected effectId: number,
               protected parameters: Array<any>) {
     super(targetNumber, targetType, effectId);
-    if (!Array.isArray(parameters) || parameters.length < 4 || parameters[1] !== 1 || parameters[2] !== 1) {
+    if (!Array.isArray(parameters) || parameters.length < 4) {
       this.parameterError = true;
     } else {
-      if (parameters[3] !== 0) {
+      if (parameters[1] !== 1 || parameters[2] !== 1 || parameters[3] !== 0) {
         this.parameterWarning = true;
       }
       this.activatedSkillId = parameters[0];


### PR DESCRIPTION
…ReplacingNormalAttackEffect

 These values don't prevent us from parsing the Skill.

Fixes #446 