### PR TITLE
 #516: Fixed issue where Vision Cards were not linked to Personnage

### DIFF
--- a/src/app/ffbe/services/characters.service.ts
+++ b/src/app/ffbe/services/characters.service.ts
@@ -100,9 +100,9 @@ export class CharactersService {
     if (character.entries) {
       const entry: CharacterEntry = character.entries[characterId];
       if (entry?.nv_upgrade?.length && entry.nv_upgrade[0].reward?.length) {
-        return entry.nv_upgrade[0].reward.some(
+        return entry.nv_upgrade.some(nv_up => nv_up.reward.some(
           (reward: Array<any>) => reward.length > 2 && reward[0] === 'VISIONCARD' && reward[1] === rewardId
-        );
+        ));
       }
     }
     return false;


### PR DESCRIPTION
 The previous implementation only checked in the Character EX+1 awakening.

Fixes #516 