### PR TITLE
  #533: Fixed crash when LimitBurst had no names

### DIFF
--- a/src/app/ffbe/mappers/character-entry-mapper.spec.ts
+++ b/src/app/ffbe/mappers/character-entry-mapper.spec.ts
@@ -84,4 +84,20 @@ describe('CharacterEntryMapper', function () {
     expect(fakeUnite.lim_frames).toEqual('11 18 25 32 39 46 53 60 67 74 81 88 95 102 109 116 123 130 137 144 151 158 165 172');
     expect(fakeUnite.lim_damages).toEqual('2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 54');
   });
+
+  it('should parse LB correctly when names are missing', () => {
+    // GIVEN
+    const lbs = JSON.parse(LIMIT_BURST_TEST_DATA);
+    const lbsNames = JSON.parse(LIMIT_BURST_NAMES_TEST_DATA);
+    const lb: LimitBurst = lbs['100031607'];
+    lb.names = lbsNames['1234'];
+    const fakeUnite = new Unite(2185, 8, 100032707, 100032707);
+
+    // WHEN
+    CharacterEntryMapper['convertLimitBurst'](fakeUnite, lb, []);
+
+    // THEN
+    expect(fakeUnite.limite).toEqual('WARN:Veracious Moon');
+    expect(fakeUnite.limite_en).toEqual('WARN:Veracious Moon');
+  });
 });

--- a/src/app/ffbe/mappers/character-entry-mapper.ts
+++ b/src/app/ffbe/mappers/character-entry-mapper.ts
@@ -81,8 +81,8 @@ export class CharacterEntryMapper {
     if (lb) {
       const minLevelFakeSkill: Skill = CharacterEntryMapper.createFakeSkillForLb(lb, 0);
       const maxLevelFakeSkill: Skill = CharacterEntryMapper.createFakeSkillForLb(lb, lb.levels.length - 1).initializeSkillEffects();
-      unite.limite = lb.names[FFBE_FRENCH_TABLE_INDEX];
-      unite.limite_en = lb.names[FFBE_ENGLISH_TABLE_INDEX];
+      unite.limite = lb.names && lb.names[FFBE_FRENCH_TABLE_INDEX] ? lb.names[FFBE_FRENCH_TABLE_INDEX] : `WARN:${lb.name}`;
+      unite.limite_en = lb.names && lb.names[FFBE_ENGLISH_TABLE_INDEX] ? lb.names[FFBE_ENGLISH_TABLE_INDEX] : `WARN:${lb.name}`;
       unite.lim_effect_min = lb.min_level.length > 0 ? lb.min_level.join('<br />') : null;
       unite.lim_effect_max = lb.max_level.length > 0 ? lb.max_level.join('<br />') : null;
       unite.lim_min = SkillEffectsMapper.mapAbilitySkillEffects(minLevelFakeSkill);

--- a/src/app/ffbe/mappers/character-entry-mapper.ts
+++ b/src/app/ffbe/mappers/character-entry-mapper.ts
@@ -81,8 +81,8 @@ export class CharacterEntryMapper {
     if (lb) {
       const minLevelFakeSkill: Skill = CharacterEntryMapper.createFakeSkillForLb(lb, 0);
       const maxLevelFakeSkill: Skill = CharacterEntryMapper.createFakeSkillForLb(lb, lb.levels.length - 1).initializeSkillEffects();
-      unite.limite = lb.names && lb.names[FFBE_FRENCH_TABLE_INDEX] ? lb.names[FFBE_FRENCH_TABLE_INDEX] : `WARN:${lb.name}`;
-      unite.limite_en = lb.names && lb.names[FFBE_ENGLISH_TABLE_INDEX] ? lb.names[FFBE_ENGLISH_TABLE_INDEX] : `WARN:${lb.name}`;
+      unite.limite = CharacterEntryMapper.getLocalisedName(lb, FFBE_FRENCH_TABLE_INDEX);
+      unite.limite_en = CharacterEntryMapper.getLocalisedName(lb, FFBE_ENGLISH_TABLE_INDEX);
       unite.lim_effect_min = lb.min_level.length > 0 ? lb.min_level.join('<br />') : null;
       unite.lim_effect_max = lb.max_level.length > 0 ? lb.max_level.join('<br />') : null;
       unite.lim_min = SkillEffectsMapper.mapAbilitySkillEffects(minLevelFakeSkill);
@@ -123,6 +123,11 @@ export class CharacterEntryMapper {
     fakeSkill.attack_damage = lb.attack_damage;
     fakeSkill.attack_frames = lb.attack_frames;
     return fakeSkill;
+  }
+
+  private static getLocalisedName(lb: LimitBurst, languageIndex: number) {
+    return lb.names && lb.names[languageIndex] ? lb.names[languageIndex] : `WARN:${lb.name}`;
+
   }
 
   private static convertAwakeningMaterials(unite: Unite, entry: CharacterEntry) {


### PR DESCRIPTION
  In this case, the (English) "name" field is used with a warning.

Fixes #533 